### PR TITLE
增加主标题和二级标题之间的分隔符

### DIFF
--- a/layout/includes/layout.swig
+++ b/layout/includes/layout.swig
@@ -1,5 +1,5 @@
 
-{% set pageTitle = page.title || config.subtitle || '' %}
+{% set pageTitle = page.title || config.subtitle  || ''%}
 
 {% if is_archive() %}
   {% set pageTitle = 'Archives' %}
@@ -21,7 +21,7 @@
   {% set pageTitle = pageTitle + ': ' + page.year %}
 {% endif %}
 
-{% set pageTitle = pageTitle + config.title %}
+{% set pageTitle = pageTitle + '  -  ' + config.title %}
 
 <!doctype html>
 <html lang="{{ config.language }}">

--- a/source/css/atom-one-dark.css
+++ b/source/css/atom-one-dark.css
@@ -20,7 +20,7 @@ hue-6-2: #e6c07b
 
 .hljs {
   display: block;
-  overflow-x: auto;
+  overflow-x: overlay;
   padding: 0.5em;
   color: #abb2bf;
   /*background: #282c34;*/


### PR DESCRIPTION
主标题和二级标题紧贴在一起，不太好。加了一个分隔符， 如有特殊需要可以在主题配置文件中增加一个变量，让用户随意修改分割字符。